### PR TITLE
Add authentication and role-based access for teachers/admins

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,9 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+import json
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
@@ -13,14 +15,32 @@ from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+security = HTTPBasic()
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
+def load_teachers():
+    with open(os.path.join(current_dir, "teachers.json"), "r") as f:
+        data = json.load(f)
+    return {t["username"]: t["password"] for t in data["teachers"]}
+
+teachers = load_teachers()
+
 # In-memory activity database
 activities = {
+    def authenticate(credentials: HTTPBasicCredentials = Depends(security)):
+        username = credentials.username
+        password = credentials.password
+        if username in teachers and teachers[username] == password:
+            return username
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -88,45 +108,30 @@ def get_activities():
     return activities
 
 
+
+# Only teachers/admins can register students
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, credentials: HTTPBasicCredentials = Depends(security)):
+    authenticate(credentials)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
+        raise HTTPException(status_code=400, detail="Student is already signed up")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
+
+# Only teachers/admins can unregister students
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, email: str, credentials: HTTPBasicCredentials = Depends(security)):
+    authenticate(credentials)
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    { "username": "teacher1", "password": "password1" },
+    { "username": "teacher2", "password": "password2" }
+  ]
+}


### PR DESCRIPTION
This PR implements authentication and role-based access for teachers and admins. Only authenticated teachers can register or unregister students for activities. Credentials are stored in teachers.json. This addresses issue #8.